### PR TITLE
Fix handling of subscripts and superscripts (including footnotes).

### DIFF
--- a/static/css/screen.css
+++ b/static/css/screen.css
@@ -167,9 +167,27 @@ div.codehilite {
 	border-radius: 5px;
 	}
 
+
 code, pre {
 	font-family: monospace;
 	background-color: rgb(238, 238, 238);
+}
+
+/*sub and sup stolen from Twitter bootstrap.*/
+sub,
+sup {
+	position: relative;
+	font-size: 75%;
+	line-height: 0;
+	vertical-align: baseline;
+}
+
+sup {
+	top: -0.5em;
+}
+
+sub {
+	bottom: -0.25em;
 }
 
 .post pre, .page pre {


### PR DESCRIPTION
Add formatting for subscripts and superscripts, which has the added bonus of making footnotes work.

Without subscripts and superscripts:
![codeexample_nosubscript](https://f.cloud.github.com/assets/1570381/670053/da5a81a2-d83a-11e2-9102-ea4d167d4928.png)

With subscripts and superscripts:
![codeexample_subscript](https://f.cloud.github.com/assets/1570381/670055/e15ffbf8-d83a-11e2-8821-134b7e8e41bd.png)
