### PR TITLE
Fix archives page with Jinja>=2.9

### DIFF
--- a/templates/archives.html
+++ b/templates/archives.html
@@ -6,19 +6,19 @@
 
                 <h1>Archives</h1>
 
-				{#- hold on to your butts! #}
+                {#- hold on to your butts! #}
 
-                {% set month = None -%}
+                {% set ctx = {'month': None} -%}
                 {%- for article in dates -%}
                 {% set cmonth = article.date.date().replace(day=1) %}
-                {%- if not month -%}
-                {%   set month = cmonth %}
+                {%- if not ctx.month -%}
+                {%   if ctx.update(month=cmonth) %}{% endif %}
 
                 <h4 class="date">{{ article.date.strftime("%b %Y") }}</h4>
                 <div class="post archives">
                     <ul>
-                {%- elif cmonth < month -%}
-                {%   set month = cmonth %}
+                {%- elif cmonth < ctx.month -%}
+                {%   if ctx.update(month=cmonth) %}{% endif %}
 
                     </ul>
                     <br />


### PR DESCRIPTION
Jinja 2.9+ (January 7th 2017) changed how scoping of variables in templates work a bit, so `set month = cmonth` from inside the loop iteration no longer works.
Don't think it was supposed to work previously, and kinda did by accident.

Solution here looks a bit hacky, but should work fine for any forseeable future.
Abusing logic in "if" avoids the need for e.g. `JINJA_EXTENSIONS = ['jinja2.ext.do']` in pelicanconf.py to have "do" command that also allows such expressions.

----------

Change, afaict, is marked as:

    Greatly changed the scoping system to be more consistent with what template designers and developers expect. ...

http://jinja.pocoo.org/docs/2.9/changelog/#version-2-9

Similar issues:
- https://github.com/pallets/jinja/issues/330
- http://stackoverflow.com/questions/9486393/jinja2-change-the-value-of-a-variable-inside-a-loop
- http://stackoverflow.com/questions/4870346/can-a-jinja-variables-scope-extend-beyond-in-an-inner-block
- http://stackoverflow.com/questions/14726396/jinja-template-variable-assignment-scope
