### PR TITLE
Fix display of static pages

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -28,7 +28,7 @@
 
                 <li {%- if output_file == "index.html" %} class="selected"{% endif %}><a href="{{ SITEURL }}">Home</a></li>
                 {% if DISPLAY_PAGES_ON_MENU -%}
-                {% for page in PAGES -%}
+                {% for page in pages -%}
                 <li {%- if output_file == page.url %} class="selected"{% endif %}><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a></li>
                 {% endfor -%}
 				{% endif -%}


### PR DESCRIPTION
With recent versions of Pelican (I looked at 3.7.1), the theme didn't show
any static page anymore.  This is because the template variable changed
name from "PAGES" to "pages" at some point.